### PR TITLE
Fix MapOptions broken link

### DIFF
--- a/maplibre/map.py
+++ b/maplibre/map.py
@@ -19,7 +19,7 @@ class MapOptions(BaseModel):
     """Map options
 
     Note:
-        See [mapOptions](https://maplibre.org/maplibre-gl-js/docs/API/types/maplibregl.MapOptions/) for more details.
+        See [mapOptions](https://maplibre.org/maplibre-gl-js/docs/API/types/MapOptions/) for more details.
     """
 
     model_config = ConfigDict(


### PR DESCRIPTION
This PR fixes the broken link to `MapOptions`

https://eodagmbh.github.io/py-maplibregl/api/map/#maplibre.MapOptions

![image](https://github.com/eodaGmbH/py-maplibregl/assets/5016453/1f9757be-1f7d-48ce-bc3c-6c770acfe114)
