### PR TITLE
Bump anywidget version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ shiny = "^0.6.1"
 htmltools = "^0.5.1"
 jinja2 = "^3.1.3"
 pydantic = "^2.5.3"
-anywidget = "^0.8.1"
+anywidget = "^0.9.0"
 pandas = {version = "^2.1.4", optional = true}
 geopandas = {version = "^0.14.2", optional = true}
 


### PR DESCRIPTION
Bump the anywidget version so that it py-maplibre is compatible with other mapping libraries such as lonboard. Otherwise, we can install both packages in the same environment. 

https://github.com/developmentseed/lonboard/blob/main/pyproject.toml#L13